### PR TITLE
Improve if

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.5] - SNAPSHOT
   ### Changed
   - Default state space (empty machine) is only loaded if needed (instead of on start-up).
+  - Add support for FREETYPES
+  - Make `if` more similar to `let`: `if-expr` was replaced by `if` which works with both expressions and predicates
 
 ## [0.0.4]
   ### Added:

--- a/src/lisb/translation/ast2lisb.clj
+++ b/src/lisb/translation/ast2lisb.clj
@@ -118,6 +118,7 @@
              ASeq1Expression
              AGeneralConcatExpression
              AIfThenElseExpression
+             AIfPredicatePredicate
              AQuantifiedIntersectionExpression
              AQuantifiedUnionExpression
              ARecEntry
@@ -500,7 +501,9 @@
 ;;; if-then-else
 
 (defmethod ast->lisb AIfThenElseExpression [node]
-  (lisbify 'if-expr (.getCondition node) (.getThen node) (.getElse node)))
+  (lisbify 'if (.getCondition node) (.getThen node) (.getElse node)))
+(defmethod ast->lisb AIfPredicatePredicate [node]
+  (lisbify 'if (.getCondition node) (.getThen node) (.getElse node)))
 
 
 ;;; let

--- a/src/lisb/translation/util.clj
+++ b/src/lisb/translation/util.clj
@@ -22,7 +22,7 @@
               bskip bblock bassign bbecomes-element-of bbecomes-such bop-call bparallel-sub bsequential-sub bany
               blet-sub bvar bprecondition bassert bchoice bif-sub bselect
               ;;; if
-              bif-expr
+              bif
               ;;; let
               blet
               ;;; trees

--- a/test/lisb/integration_test.clj
+++ b/test/lisb/integration_test.clj
@@ -285,8 +285,8 @@
 (deftest fancy-fns-test
   (testing "fancier functions"
     (is (eval-ir-formula (b= #{2 3 4} (bmap-set (pred [x] (+ 1 x)) #{1 2 3}))))
-    (is (eval-ir-formula (b= (bif-expr (b< 1 2) 3 4) 3)))
-    (is (eval-ir-formula (b= (bif-expr (b> 1 2) 3 4) 4)))
+    (is (eval-ir-formula (b= (bif (b< 1 2) 3 4) 3)))
+    (is (eval-ir-formula (b= (bif (b> 1 2) 3 4) 4)))
     (is (eval-ir-formula (b= (brange 1 5) #{1 2 3 4})))
     (is (eval-ir-formula (eval `(b ~(ast->lisb (b-predicate->ast "1<2"))))))
     (is (eval-ir-formula (b= 2 (eval `(b ~(ast->lisb (b-expression->ast "1+1")))))))

--- a/test/lisb/translation/ast2lisb_test.clj
+++ b/test/lisb/translation/ast2lisb_test.clj
@@ -130,7 +130,7 @@
 (deftest if-test
   (testing "if"
     (are [lisb b] (= lisb (b-expression->lisb b))
-                             '(if-expr (= 1 1) 2 3) "IF 1=1 THEN 2 ELSE 3 END")
+                             '(if (= 1 1) 2 3) "IF 1=1 THEN 2 ELSE 3 END")
     (are [lisb b] (= lisb (b-predicate->lisb b))
                   '(and (=> (= 1 1) (= 2 2)) (=> (not (= 1 1)) (= 3 3))) "IF 1=1 THEN 2=2 ELSE 3=3 END")))
 

--- a/test/lisb/translation/circle_test.clj
+++ b/test/lisb/translation/circle_test.clj
@@ -65,7 +65,7 @@
 (deftest if-test
   (testing "if"
     (are [ir] (= ir (ast->ir (ir->ast ir)))
-              (b (if-expr (= 1 1) 2 3)))))
+              (b (if (= 1 1) 2 3)))))
 
 (deftest let-test
   (testing "let"

--- a/test/lisb/translation/ir2ast_test.clj
+++ b/test/lisb/translation/ir2ast_test.clj
@@ -136,7 +136,7 @@
 (deftest if-test
   (testing "if"
     (are [b ir] (= b (ast->b (ir->ast ir)))
-                  "IF 1=1 THEN 2 ELSE 3 END" (b (if-expr (= 1 1) 2 3)))
+                  "IF 1=1 THEN 2 ELSE 3 END" (b (if (= 1 1) 2 3)))
     (are [b ir] (= b (ast->b (ir->ast ir)))
                   "(1=1 => 2=2) & (not(1=1) => 3=3)" (b (and (=> (= 1 1) (= 2 2)) (=> (not (= 1 1)) (= 3 3)))))))
 


### PR DESCRIPTION
Make `if` more similar to `let`: `if-expr` was replaced by `if` which works with both expressions and predicates.

Because `if` is a special form in Clojure a new case was added to `pre-process-lisb` to replace the symbol with the correct one (`bif`).