### PR TITLE
Add support for n-ary tuples in maplet

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Default state space (empty machine) is only loaded if needed (instead of on start-up).
   - Add support for FREETYPES
   - Make `if` more similar to `let`: `if-expr` was replaced by `if` which works with both expressions and predicates
+  - add support for n-ary tuples in `maplet`
 
 ## [0.0.4]
   ### Added:

--- a/doc/Lisb.md
+++ b/doc/Lisb.md
@@ -110,8 +110,8 @@
 | `set1<<->set2<<->...`                                | `(<<-> & sets)`                     | `{:tag :total relation, :sets sets}`             | total relation                                                   |
 | `set1<->>set2<<->...`                                | `(<->> & sets)`                     | `{:tag :surjective relation , :sets sets}`       | surjective relation                                              |
 | `set1<<->>set2<<->...`                               | `(<<->> & sets)`                    | `{:tag :total surjective relation, :sets sets}`  | total surjective relation                                        |
-| <code>left&#124;->right</code>                       |  <code>(&#124;-> left right)</code> | `{:tag :maplet, :left left, :right right}`       | maplet                                                           |
-|                                                      | `(maplet left right)`               | `{:tag :maplet, :left left, :right right}`       | sugar                                                            | 
+| <code>left&#124;->right</code>                       |  <code>(&#124;-> & elems)</code> | `{:tag :maplet, :elems elems}`       | maplet                                                           |
+|                                                      | `(maplet & elems)`               | `{:tag :maplet, :elems elems}`       | sugar                                                            | 
 | `dom(rel)`                                           | `(dom rel)`                         | `{:tag :dom, :rel rel}`                          | domain of relation                                               |
 | `ran(rel)`                                           | `(ran rel)`                         | `{:tag :ran, :rel rel}`                          | range of relation                                                |
 | `id(set)`                                            | `(id set)`                          | `{:tag :id, :set set}`                           | identity relation                                                |

--- a/src/lisb/translation/ir2ast.clj
+++ b/src/lisb/translation/ir2ast.clj
@@ -819,8 +819,8 @@
   (left-associative #(ATotalSurjectionRelationExpression. %1 %2) (ir-node-sets->ast ir-node)))
 
 (defmethod ir-node->ast-node :maplet [ir-node]
-  (s/assert (s/keys :req-un [::left ::right]) ir-node)
-  (ACoupleExpression. [(ir-node-left->ast ir-node) (ir-node-right->ast ir-node)]))
+  (s/assert (s/keys :req-un [::elems]) ir-node)
+  (ACoupleExpression. (ir-node-elems->ast ir-node)))
 
 (defmethod ir-node->ast-node :dom [ir-node]
   (s/assert (s/keys :req-un [::rel]) ir-node)
@@ -1167,7 +1167,6 @@
   (cond
     (map? ir) (ir-node->ast-node ir)
     (set? ir) (set-expression (map ir->ast-node ir))
-    ;(vector? ir) (ACoupleExpression. (map ir->ast-node ir))
     (keyword? ir) (AIdentifierExpression. [(TIdentifierLiteral. (name ir))])
     (string? ir) (AStringExpression. (TStringLiteral. ir)) ;; hack-y thing to avoid renaming of rec-get parameters in preds
     (integer? ir) (AIntegerExpression. (TIntegerLiteral. (str ir)))

--- a/src/lisb/translation/lisb2ir.clj
+++ b/src/lisb/translation/lisb2ir.clj
@@ -908,13 +908,12 @@
         :ret (s/and (s/keys :req-un (::tag) :req (::sets))
                     #(= :total-surjective-relation (:tag %))))
 
-(defn bmaplet [left right]
+(defn bmaplet [& elems]
   {:tag :maplet
-   :left left
-   :right right})
+   :elems elems})
 (s/fdef bmaplet
-        :args (s/cat :left ::left :right ::right)
-        :ret (s/and (s/keys :req-un (::tag) :req (::left ::right))
+        :args (s/cat :elems ::elems)
+        :ret (s/and (s/keys :req-un (::tag) :req (::elems))
                     #(= :maplet (:tag %))))
 
 (defn bdom [rel]

--- a/test/lisb/integration_test.clj
+++ b/test/lisb/integration_test.clj
@@ -129,6 +129,9 @@
     (is (eval-ir-formula (b= 2 (bsuccessor 1))))
 
     (is (eval-ir-formula (b= 0 (bpredecessor 1))))
+    
+    (is (eval-ir-formula (b= :x (bmaplet 1 2))))
+    (is (eval-ir-formula (b= :x (bmaplet 1 2 3))))
 
     (is (eval-ir-formula (b= :x #{(bmaplet 1 2)})))
 

--- a/test/lisb/translation/circle_test.clj
+++ b/test/lisb/translation/circle_test.clj
@@ -143,6 +143,7 @@
               (b (<->> :S :T))
               (b (<<->> :S :T))
               (b (|-> :E :F))
+              (b (|-> :E :F :G))
               (b (dom :r))
               (b (ran :r))
               (b (identity :S))

--- a/test/lisb/translation/ir2ast_test.clj
+++ b/test/lisb/translation/ir2ast_test.clj
@@ -242,6 +242,7 @@
                 "S<<->>T<<->>U" (b (<<->> :S :T :U))
                 "S<<->>T<<->>U<<->>V" (b (<<->> :S :T :U :V))
                 "(E,F)" (b (maplet :E :F))
+                "(E,F,G)" (b (maplet :E :F :G))
                 "dom(r)" (b (dom :r))
                 "ran(r)" (b (ran :r))
                 "id(S)" (b (id :S))


### PR DESCRIPTION
This was removed in https://github.com/pkoerner/lisb/commit/d1aa0ee9c179a81a035a40a98da9a9565d410bf2
Previously tuples were written as clojure vecs, but that was changed to `maplet`.
I made `maplet` take arbitrary amount of args.
Curiously the AST->LisB translation already assumed that.