### PR TITLE
Fix potential problems due to private value-translator classes used i…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,6 @@
                  [org.clojure/test.check "1.1.1"]
                  [potemkin "0.4.7"]
                  [com.rpl/specter "1.1.4"]
-                 [clj-wallhack "1.0.1"]
                  [de.hhu.stups/prob-java "4.13.2-SNAPSHOT"]
                  [de.hhu.stups/value-translator "0.2.0-SNAPSHOT"]
                  ])

--- a/src/lisb/prob/retranslate.clj
+++ b/src/lisb/prob/retranslate.clj
@@ -36,4 +36,4 @@
                 (assoc m (keyword (.getKey e)) (retranslate (.getValue e))))
               {}
               (.toMap data))
-    (throw (IllegalArgumentException. (str "unexpected value to retranslate: " data)))))
+    (throw (IllegalArgumentException. (str "unsupported value for retranslate: " data)))))

--- a/src/lisb/prob/retranslate.clj
+++ b/src/lisb/prob/retranslate.clj
@@ -1,8 +1,7 @@
 (ns lisb.prob.retranslate
-  (:require [wall.hack :refer [method]])
   (:require [lisb.translation.types :refer [->Tuple]])
   (:import
-    (de.hhu.stups.prob.translator BAtom BBoolean BNumber BRecord BSet BString BTuple BReal BSmallNumber BBigNumber)
+    (de.hhu.stups.prob.translator BAtom BBoolean BNumber BRecord BSet BString BTuple BReal)
     (de.hhu.stups.prob.translator.interpretations BFunction BRelation BSequence)))
 
 
@@ -11,9 +10,8 @@
     ; value types
     BAtom (.stringValue data)
     BBoolean (.booleanValue data)
-    BSmallNumber (.longValue data)     ;; not sure if needed
-    BBigNumber (.bigIntegerValue data) ;; not sure if needed
-    BNumber (if (.longValueExact data) (.longValue data) (.bigIntegerValue data))
+    BNumber (try (.longValueExact data)
+                 (catch ArithmeticException _ (.bigIntegerValue data)))
     BString (.stringValue data)
     BReal (.floatValue data)
     ; interpreted collection types of set
@@ -38,6 +36,4 @@
                 (assoc m (keyword (.getKey e)) (retranslate (.getValue e))))
               {}
               (.toMap data))
-    de.hhu.stups.prob.translator.TranslatingVisitor$RecordEntry [(method de.hhu.stups.prob.translator.TranslatingVisitor$RecordEntry 'getKey [] data)
-                                                                 (retranslate (method de.hhu.stups.prob.translator.TranslatingVisitor$RecordEntry 'getValue [] data))]))
-
+    (throw (IllegalArgumentException. (str "unexpected value to retranslate: " data)))))

--- a/src/lisb/prob/retranslate.clj
+++ b/src/lisb/prob/retranslate.clj
@@ -13,7 +13,7 @@
     BNumber (try (.longValueExact data)
                  (catch ArithmeticException _ (.bigIntegerValue data)))
     BString (.stringValue data)
-    BReal (.floatValue data)
+    BReal (.doubleValue data)
     ; interpreted collection types of set
     BSequence (mapv retranslate (.toList data))
     BFunction (reduce


### PR DESCRIPTION
…n retranslate

`BSmallNumber` and `BBigNumber` are internal classes.
Same goes for `RecordEntry`.
They are private for a reason and might change anytime.

Also removes a dependency ;)